### PR TITLE
Add AzureFunctionsOptions.RoutePrefix

### DIFF
--- a/Swashbuckle.AspNetCore.AzureFunctions/Application/AzureFunctionsOptions.cs
+++ b/Swashbuckle.AspNetCore.AzureFunctions/Application/AzureFunctionsOptions.cs
@@ -5,5 +5,17 @@ namespace Swashbuckle.AspNetCore.AzureFunctions.Application
     public class AzureFunctionsOptions
     {
         public Assembly Assembly { get; set; }
+
+        /// <summary>
+        /// The route prefix that applies to all HTTP Trigger routes.
+        /// Default: "api"
+        /// </summary>
+        /// <remarks>
+        /// If you have modified the route prefix in your function's host.json 
+        /// file, it should be changed here to match. Use an empty string to
+        /// remove the default prefix.
+        /// See also: https://docs.microsoft.com/en-us/azure/azure-functions/functions-host-json#http
+        /// </remarks>
+        public string RoutePrefix { get; set; } = "api";
     }
 }

--- a/Swashbuckle.AspNetCore.AzureFunctions/Extensions/ServiceCollectionExtensions.cs
+++ b/Swashbuckle.AspNetCore.AzureFunctions/Extensions/ServiceCollectionExtensions.cs
@@ -21,10 +21,15 @@ namespace Swashbuckle.AspNetCore.AzureFunctions.Extensions
         /// </summary>
         /// <param name="services">Service collection</param>
         /// <param name="functionAssembly">Functions assembly</param>
-        public static void AddAzureFunctionsApiProvider(this IServiceCollection services, Assembly functionAssembly)
+        /// <param name="routePrefix">HTTP functions route prefix</param>
+        public static void AddAzureFunctionsApiProvider(this IServiceCollection services, Assembly functionAssembly, string routePrefix = "api")
         {
             services.AddOptions();
-            services.Configure<AzureFunctionsOptions>(o => o.Assembly = functionAssembly);
+            services.Configure<AzureFunctionsOptions>(o => 
+            {
+                o.Assembly = functionAssembly;
+                o.RoutePrefix = routePrefix;
+            });
             services.AddSingleton<IApiDescriptionGroupCollectionProvider, FunctionApiDescriptionProvider>();
         }
 

--- a/Swashbuckle.AspNetCore.AzureFunctions/Providers/FunctionApiDescriptionGroupCollectionProvider.cs
+++ b/Swashbuckle.AspNetCore.AzureFunctions/Providers/FunctionApiDescriptionGroupCollectionProvider.cs
@@ -23,10 +23,10 @@ namespace Swashbuckle.AspNetCore.AzureFunctions.Providers
 
         public FunctionApiDescriptionProvider(IOptions<AzureFunctionsOptions> functionsOptions)
         {
-            Initialize(functionsOptions.Value.Assembly);
+            Initialize(functionsOptions.Value.Assembly, functionsOptions.Value.RoutePrefix);
         }
 
-        private void Initialize(Assembly functionsAssembly)
+        private void Initialize(Assembly functionsAssembly, string routePrefix)
         {
             var methods = functionsAssembly.GetTypes()
                 .SelectMany(t => t.GetMethods())
@@ -40,7 +40,8 @@ namespace Swashbuckle.AspNetCore.AzureFunctions.Providers
                     continue;
 
                 var functionAttr = (FunctionNameAttribute)methodInfo.GetCustomAttribute(typeof(FunctionNameAttribute), false);
-                var route = $"api/{(!string.IsNullOrWhiteSpace(triggerAttribute.Route) ? triggerAttribute.Route : functionAttr.Name)}";
+                var prefix = string.IsNullOrWhiteSpace(routePrefix) ? "" : $"{routePrefix.TrimEnd('/')}/";
+                var route = $"{prefix}{(!string.IsNullOrWhiteSpace(triggerAttribute.Route) ? triggerAttribute.Route : functionAttr.Name)}";
                 var verbs = triggerAttribute.Methods ?? new[] { "get", "post", "delete", "head", "patch", "put", "options" };
                 var items = new List<ApiDescription>();
                 foreach (string verb in verbs)


### PR DESCRIPTION
This option allows for the specification of a route prefix, ala the `host.json` spec. Defaults to "api". 

Resolves #3 